### PR TITLE
Bump actions/checkout to v4

### DIFF
--- a/.github/workflows/checkin.yml
+++ b/.github/workflows/checkin.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install requirements
         run: |
           pip3 install -r ./requirements.txt


### PR DESCRIPTION
V3 versions are deprecated.